### PR TITLE
CGIV-857 added apt dependency

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,6 +5,7 @@ license           "Apache 2.0"
 description       "Installs and maintains php and php modules"
 version           "1.2.3"
 
+depends "apt"
 depends "build-essential"
 depends "xml"
 depends "mysql"


### PR DESCRIPTION
`recipes/repository.rb` was added since forking, which added an apt dependency
